### PR TITLE
Add the missing i386 slice to the Geth compiled library.

### DIFF
--- a/add_386.sh
+++ b/add_386.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find . -name bind_iosapp.go -print | xargs sed -i '' 's/darwinArmEnv, darwinArm64Env, darwinAmd64Env/darwinArmEnv, darwin386Env, darwinArm64Env, darwinAmd64Env/g'

--- a/build/ci.go
+++ b/build/ci.go
@@ -839,6 +839,8 @@ func doXCodeFramework(cmdline []string) {
 	env := build.Env()
 
 	// Build the iOS XCode framework
+	build.MustRun(goTool("get", "-d", "golang.org/x/mobile/cmd/gomobile"))
+	build.MustRunCommand("bash", "add_386.sh")
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
 	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")


### PR DESCRIPTION
This adds the i386 slice for iOS Geth framework.