### PR TITLE
Make ios 386

### DIFF
--- a/add_386.sh
+++ b/add_386.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-find . -name bind_iosapp.go -print | xargs sed -i '' 's/darwinArmEnv, darwinArm64Env, darwinAmd64Env/darwinArmEnv, darwin386Env, darwinArm64Env, darwinAmd64Env/g'

--- a/add_386.sh
+++ b/add_386.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find . -name bind_iosapp.go -print | xargs sed -i '' 's/darwinArmEnv, darwinArm64Env, darwinAmd64Env/darwinArmEnv, darwin386Env, darwinArm64Env, darwinAmd64Env/g'

--- a/build/ci.go
+++ b/build/ci.go
@@ -839,9 +839,7 @@ func doXCodeFramework(cmdline []string) {
 	env := build.Env()
 
 	// Build the iOS XCode framework
-	build.MustRun(goTool("get", "-d", "golang.org/x/mobile/cmd/gomobile"))
-	build.MustRunCommand("bash", "add_386.sh")
-	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
+	build.MustRun(goTool("get", "github.com/kinfoundation/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
 	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -839,7 +839,10 @@ func doXCodeFramework(cmdline []string) {
 	env := build.Env()
 
 	// Build the iOS XCode framework
-	build.MustRun(goTool("get", "github.com/kinfoundation/mobile/cmd/gomobile"))
+  // Clone kinfoundation's golang mobile fork that includes 386 slice for binding ios framework
+	build.MustRun(goTool("get", "-d", "golang.org/x/mobile/cmd/gomobile"))
+	build.MustRunCommand("bash", "clone_kin_mobile.sh")
+	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
 	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -839,6 +839,8 @@ func doXCodeFramework(cmdline []string) {
 	env := build.Env()
 
 	// Build the iOS XCode framework
+	build.MustRun(goTool("get", "-d", "golang.org/x/mobile/cmd/gomobile"))
+	build.MustRunCommand("bash", "add_386.sh")
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
 	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")

--- a/clone_kin_mobile.sh
+++ b/clone_kin_mobile.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+curr_dir=$PWD
+cd $GOPATH/src/golang.org/x
+rm -rf mobile
+git clone git@github.com:kinfoundation/mobile.git
+cd $curr_dir


### PR DESCRIPTION
add build 386 slice for ios by cloning kinfoundation's golang mobile fork that includes 386 slice for binding ios framework